### PR TITLE
Add test page

### DIFF
--- a/.zenve/agents/react-dev/memory/long_term.md
+++ b/.zenve/agents/react-dev/memory/long_term.md
@@ -11,3 +11,4 @@
 - `ui/` now includes a Supabase browser client wrapper in `src/lib/supabase.ts` plus a Redux `auth` domain for email/password sign-in, sign-up, sign-out, and session initialization.
 - Host routes are now guarded: `/auth` is public, `/` is private, and public booking routes remain open. The host overview currently uses mock event data even after authentication.
 - Frontend Supabase env support now expects `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY`, with fallback support for `VITE_SUPABASE_ANON_KEY`.
+- `ui/src/pages/test.tsx` is now a lightweight public `/test` smoke-test route with a simple editorial card and button, intended for quick frontend verification.

--- a/.zenve/agents/react-dev/memory/scratch.md
+++ b/.zenve/agents/react-dev/memory/scratch.md
@@ -1,5 +1,4 @@
-Completed issue #25 Supabase auth integration:
-- Added `@supabase/supabase-js`, a typed `auth` Redux slice, and `src/lib/supabase.ts` for browser client setup.
-- Added `/auth` with a warm editorial sign-in/sign-up form adapted from the requested shadcn `login-03` block.
-- Guarded `/` behind `PrivateRoute`, kept public booking routes open, and added sign-out from the host overview.
-- Verified `pnpm build` in `ui/`; Vite reported a non-blocking large chunk warning.
+Latest run summary:
+- Fixed PR #27 review items in local changes: removed the stray `.zenve/settings.json` diff, renamed `HomePage` to `TestPage`, removed the unused import, and exposed the page at `/test`.
+- Updated PR #27 body via `gh api` because `gh pr edit` was blocked by missing token scopes.
+- Verified `pnpm lint` and `pnpm build` in `ui/`; build still shows the existing large chunk warning only.

--- a/.zenve/settings.json
+++ b/.zenve/settings.json
@@ -4,6 +4,7 @@
   "default_branch": "main",
   "commit_message_prefix": "[zenve]",
   "run_timeout_seconds": 600,
+  "run_schedule": "0 0 * * *",
   "pipeline": {
     "zenve:fastapi-dev": null,
     "zenve:pm": "zenve:react-architect",

--- a/.zenve/settings.json
+++ b/.zenve/settings.json
@@ -4,7 +4,6 @@
   "default_branch": "main",
   "commit_message_prefix": "[zenve]",
   "run_timeout_seconds": 600,
-  "run_schedule": "0 0 * * *",
   "pipeline": {
     "zenve:fastapi-dev": null,
     "zenve:pm": "zenve:react-architect",

--- a/ui/src/pages/test.tsx
+++ b/ui/src/pages/test.tsx
@@ -1,0 +1,19 @@
+import { HostEventsOverview } from '@/components/host-events'
+import { Button } from '@/components/ui/button'
+
+export default function HomePage() {
+  const renderMain = () => {
+    return (
+        <Button variant="outline" size="lg">
+            Click Me
+        </Button>
+    )
+  }
+
+  return (
+    <div>
+        <h1>Test Page</h1>
+        {renderMain()}
+    </div>
+  )
+}

--- a/ui/src/pages/test.tsx
+++ b/ui/src/pages/test.tsx
@@ -1,19 +1,24 @@
-import { HostEventsOverview } from '@/components/host-events'
 import { Button } from '@/components/ui/button'
 
-export default function HomePage() {
-  const renderMain = () => {
-    return (
-        <Button variant="outline" size="lg">
-            Click Me
-        </Button>
-    )
-  }
-
-  return (
-    <div>
-        <h1>Test Page</h1>
-        {renderMain()}
-    </div>
+export default function TestPage() {
+  const renderMain = () => (
+    <main className="min-h-screen px-4 py-8 sm:px-6 sm:py-10">
+      <div className="mx-auto flex w-full max-w-3xl justify-center">
+        <section className="editorial-panel w-full max-w-xl space-y-6 px-6 py-8 text-center sm:px-8">
+          <div className="space-y-3">
+            <p className="editorial-kicker">test page</p>
+            <h1 className="font-editorial text-4xl leading-tight text-foreground">UI smoke test surface</h1>
+            <p className="text-sm leading-6 text-muted-foreground sm:text-[15px]">
+              This route exists for quick visual checks while iterating on components.
+            </p>
+          </div>
+          <div className="flex justify-center">
+            <Button size="lg">Click me</Button>
+          </div>
+        </section>
+      </div>
+    </main>
   )
+
+  return renderMain()
 }

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -3,6 +3,7 @@ import { PrivateRoute, PublicRoute } from '@/components/auth'
 import AuthPage from '@/pages/auth'
 import HomePage from '@/pages/home'
 import PublicBookingPage from '@/pages/public-booking-page'
+import TestPage from '@/pages/test'
 
 export default function AppRoutes() {
   return (
@@ -23,6 +24,7 @@ export default function AppRoutes() {
           </PublicRoute>
         }
       />
+      <Route path="/test" element={<TestPage />} />
       <Route path="/:workspaceSlug/:eventSlug" element={<PublicBookingPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>


### PR DESCRIPTION
## Summary
- add a dedicated `/test` route for quick frontend smoke checks
- replace the rough placeholder with a named `TestPage` component that matches the current Zenve design language
- remove the unrelated `.zenve/settings.json` change from the branch

## Tracking
- No GitHub issue or docs task exists in this repository for this PR yet.
